### PR TITLE
-CC=gcc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 NAME=pxz
 VERSION=4.999.9beta
-CC=gcc
 CFLAGS?=-O2 -Wall -Wshadow -Wcast-align -Winline -Wextra -Wmissing-noreturn -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 CFLAGS+=-fopenmp
 LDFLAGS+=-llzma


### PR DESCRIPTION
Hi :)

CC in make already defaults to "cc" is unset. This can be expected to exist (and be gcc on linux); furthermore, exporting CC=clang should suffice, I shouldn't be required to pass CC=clang explicitly to make.

Kind regards,

Elias Pipping
