### PR TITLE
Correct manpage for -c and -k options

### DIFF
--- a/pxz.1
+++ b/pxz.1
@@ -21,10 +21,10 @@ Display help.
 Force operation.
 .TP
 .I "\-c," "\-\-stdout"
-Write results to standard output.
+Write results to standard output and don't delete input files.
 .TP
 .I "\-k," "\-\-keep"
-Write results to standard output.
+Keep (don't delete) input files.
 .TP
 .I "\-T," "\-\-threads"
 Maximal number of threads to run simultaneously.


### PR DESCRIPTION
The manpage has the wrong description for -k and only partially describes -c. I corrected them based on the -h output.
