### PR TITLE
support --format=[xz|lzma|auto|alone]

### DIFF
--- a/pxz.1
+++ b/pxz.1
@@ -32,6 +32,19 @@ Maximal number of threads to run simultaneously.
 .I "\-D," "\-\-context\-size"
 Context size per one thread specified as a multiple of dictionary size for active compression level.
 .TP
+.BI \-F\  format \fR,\ \fB\-\-format= format
+Specify the file format to compress.
+Options are:
+.BR auto\
+,
+.BR xz\
+,
+.BR lzma\
+,
+and
+.BR alone\
+.
+.TP
 .I "\-V," "\-\-version"
 Display version of PXZ.
 .SH EXAMPLES


### PR DESCRIPTION
Add support for the `-F` / `--format` flag. This has similar mechanics to
xz's `--format` flag, which means `pxz --format=lzma` is now a drop-in
replacement for `lzma`:

```
    echo hello | pxz --format=lzma | unlzma
    => hello
```

Relevant code was pilfered from XZ Utils.

PS - nice job keeping such a simple repo, this change was super easy to make. Let me know if you want any changes.