### PR TITLE
Fix memory leak

### DIFF
--- a/pxz.c
+++ b/pxz.c
@@ -455,6 +455,7 @@ int main( int argc, char **argv ) {
 		}
 
 		free(ftemp);
+		free(m);
 		
 		if ( fo != stdout ) {
 			if ( close_stream(fo) ) {


### PR DESCRIPTION
When many files are specified on the command line, a lot of memory
is leaked.  Free the space which is being leaked.
