### PR TITLE
CVE-2015-1200: Race condition in setting permissions on output file

### DIFF
--- a/pxz.c
+++ b/pxz.c
@@ -312,6 +312,7 @@ int main( int argc, char **argv, char **envp ) {
 		}
 		
 		fo = stdout;
+		umask(077);
 		if ( std_in ) {
 			fi = stdin;
 		} else {


### PR DESCRIPTION
Race condition in pxz 4.999.99 Beta 3 uses weak file permissions
for the output file when compressing a file before changing the
permission to match the original file, which allows local users
to bypass the intended access restrictions.

Patch by Moritz Mühlenhoff

See also:
 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2015-1200
 - https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775306
 - https://bugzilla.redhat.com/show_bug.cgi?id=1182024