### PR TITLE
Updated default path for xz binary

### DIFF
--- a/pxz.c
+++ b/pxz.c
@@ -43,7 +43,7 @@
 #endif
 
 #ifndef XZ_BINARY
-#define XZ_BINARY "xz"
+#define XZ_BINARY "/usr/bin/xz"
 #endif
 
 #define BUFFSIZE 0x10000


### PR DESCRIPTION
Fixes #34 - sets a sane default for the xz binary that should work on many platforms.
Distributions with different binary layouts can use `export CFLAGS="$CFLAGS -DXZ_BINARY='\"/usr/bin/xz\"'"` as pointed out by Robert Scheck to adjust the xz binary path.